### PR TITLE
Enable tiering of historical through helm chart

### DIFF
--- a/templates/historical/tieredStatefulset
+++ b/templates/historical/tieredStatefulset
@@ -1,0 +1,184 @@
+{{/*
+
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+*/}}
+
+{{- if .Values.historical.enabled -}}
+{{- if .Values.historical.tiers -}}
+{{- range .Values.historical.tierData }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: {{ template "druid.name" $ }}-{{ .name }}
+    chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    component: {{ $.Values.historical.name }}
+    heritage: {{ $.Release.Service }}
+    release: {{ $.Release.Name }}
+  name: {{ template "druid.historical.fullname" $ }}-{{ .name }}
+spec:
+  serviceName: {{ template "druid.historical.fullname" $ }}-{{ .name }}
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "druid.name" $ }}-{{ .name }}
+      release: {{ $.Release.Name }}
+      component: {{ $.Values.historical.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "druid.name" $ }}-{{ .name }}
+        component: {{ $.Values.historical.name }}
+        release: {{ $.Release.Name }}
+      annotations:
+        druid.k8s.enablePatching: "true"
+        {{- with $.Values.historical.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.prometheus.enabled }}
+          {{- with $.Values.prometheus.annotation }}
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
+    spec:
+      {{- if or $.Values.historical.antiAffinity $.Values.historical.nodeAffinity }}
+      affinity:
+      {{- end }}
+      {{- if eq $.Values.historical.antiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: "{{ template "druid.name" $ }}"
+                  release: "{{ $.Release.Name }}"
+                  component: "{{ $.Values.historical.name }}"
+      {{- else if eq $.Values.historical.antiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: "{{ template "druid.name" $ }}"
+                    release: "{{ $.Release.Name }}"
+                    component: "{{ $.Values.historical.name }}"
+      {{- end }}
+      {{- with $.Values.historical.nodeAffinity }}
+        nodeAffinity:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+{{- if .nodeSelector }}
+      nodeSelector:
+{{ toYaml .nodeSelector | indent 8 }}
+{{- end }}
+{{- if $.Values.historical.securityContext }}
+      securityContext:
+{{ toYaml $.Values.historical.securityContext | indent 8 }}
+{{- end }}
+{{- if .tolerations }}
+      tolerations:
+{{ toYaml .tolerations | indent 8 }}
+{{- end }}
+{{- if $.Values.image.pullSecrets }}
+      imagePullSecrets:
+{{ toYaml $.Values.image.pullSecrets | indent 8 }}
+{{- end }}
+      {{- if $.Values.historical.serviceAccount.create }}
+      serviceAccountName: {{ include "druid.historical.serviceAccountName" $ }}
+      {{- end }}
+      containers:
+        - name: druid
+          args: [ "historical" ]
+          env:
+            - name: POD_NAME
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - name: POD_NAMESPACE
+              valueFrom: { fieldRef: { fieldPath: metadata.namespace } }
+        {{- range $key, $val := .config }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+        {{- end}}
+          envFrom:
+            - secretRef:
+                name: common-runtime-secrets
+            - configMapRef:
+                name: {{ template "druid.name" $ }}
+          resources:
+{{ toYaml .resources | indent 12 }}
+          livenessProbe:
+            initialDelaySeconds: {{ $.Values.historical.livenessProbeInitialDelaySeconds }}
+            httpGet:
+              path: /status/health
+              port: {{ $.Values.historical.port }}
+          readinessProbe:
+            initialDelaySeconds: {{ $.Values.historical.readinessProbeInitialDelaySeconds }}
+            httpGet:
+              path: /status/health
+              port: {{ $.Values.historical.port }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy | quote }}
+          ports:
+            - containerPort: {{ $.Values.historical.port }}
+              name: http
+        {{- if $.Values.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ $.Values.prometheus.port }}
+              protocol: TCP
+        {{- end }}
+          volumeMounts:
+            - mountPath: /opt/druid/var/druid/
+              name: data
+  {{- if $.Values.gCloudStorage.enabled }}
+            - name: google-cloud-key
+              mountPath: /var/secrets/google
+  {{- end }}
+      volumes:
+  {{- if not $.Values.historical.persistence.enabled }}
+        - name: data
+          emptyDir: { }
+  {{- end }}
+  {{- if $.Values.gCloudStorage.enabled }}
+        - name: google-cloud-key
+          secret:
+            secretName: {{ $.Values.gCloudStorage.secretName }}
+  {{- end }}
+  updateStrategy:
+    type: {{ $.Values.historical.updateStrategy.type }}
+  {{- if $.Values.historical.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ $.Values.historical.persistence.accessMode | quote }}
+    {{- if $.Values.historical.persistence.storageClass }}
+    {{- if (eq "-" $.Values.historical.persistence.storageClass) }}
+        storageClassName: ""
+    {{- else }}
+        storageClassName: "{{ $.Values.historical.persistence.storageClass }}"
+    {{- end }}
+    {{- end }}
+        resources:
+          requests:
+            storage: "{{ $.Values.historical.persistence.size }}"
+  {{- end }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -299,6 +299,58 @@ historical:
   updateStrategy:
     type: RollingUpdate
 
+  ## If tiered historical is set to true, please refer to the information under 'tierData' for customisation of historical.
+  ## All data given above would be overridden by the information in 'tierData' unless not specified.
+  tiers: true
+
+  ## The following will be effective only when tiers are enabled
+  tierData:
+    - name: default
+      replicas: 1
+      nodeSelector: {}
+      tolerations: []
+      resources: {}
+        # limits:
+        #   cpu: 2
+        #   memory: 2Gi
+        # requests:
+        #   cpu: 500m
+        #   memory: 512Mi
+      config:
+        DRUID_XMX: 512m
+        DRUID_XMS: 512m
+        DRUID_MAXDIRECTMEMORYSIZE: 400m
+        druid_processing_buffer_sizeBytes: '50000000'
+        druid_processing_numMergeBuffers: 2
+        druid_processing_numThreads: 1
+        # druid_monitoring_monitors: '["org.apache.druid.client.cache.CacheMonitor", "org.apache.druid.server.metrics.HistoricalMetricsMonitor", "org.apache.druid.server.metrics.QueryCountStatsMonitor"]'
+        # druid_segmentCache_locations: '[{"path":"/opt/druid/var/druid/segment-cache","maxSize":300000000000}]'
+        druid_server_tier: default
+        druid_server_priority: 0
+    - name: hot
+      replicas: 1
+      nodeSelector: {}
+      tolerations: []
+      resources: {}
+        # limits:
+        #   cpu: 2
+        #   memory: 2Gi
+        # requests:
+        #   cpu: 500m
+        #   memory: 512Mi
+      config:
+        DRUID_XMX: 512m
+        DRUID_XMS: 512m
+        DRUID_MAXDIRECTMEMORYSIZE: 400m
+        druid_processing_buffer_sizeBytes: '50000000'
+        druid_processing_numMergeBuffers: 2
+        druid_processing_numThreads: 1
+        # druid_monitoring_monitors: '["org.apache.druid.client.cache.CacheMonitor", "org.apache.druid.server.metrics.HistoricalMetricsMonitor", "org.apache.druid.server.metrics.QueryCountStatsMonitor"]'
+        # druid_segmentCache_locations: '[{"path":"/opt/druid/var/druid/segment-cache","maxSize":300000000000}]'
+        druid_server_tier: hot
+        druid_server_priority: 1
+        
+
 middleManager:
   ## If false, middleManager will not be installed
   ##


### PR DESCRIPTION
## Enable tiered historical through helm chart

Tiered historical service contributes greatly to the performance of Druid and query latency. 
This patch provides easy tiering of historical during k8s deployment directly from the values file of the helm chart.

This has been tested on k8s cluster with two tiers, namely hot and default and the results are satisfying.

<img width="1504" alt="Screenshot 2024-05-20 at 6 13 22 PM" src="https://github.com/asdf2014/druid-helm/assets/54573581/f2828946-25ae-4b92-9b37-e74b19dcf748">
