### PR TITLE
Update helm chart port forwarding commands

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -32,7 +32,7 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "druid.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.router.port }}
 {{- else if contains "ClusterIP" .Values.router.serviceType }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "druid.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.router.port }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "druid.name" . }},release={{ .Release.Name }}" --no-headers -o custom-columns=":metadata.name" | grep "^my-druid-router")
+  echo "Visit http://127.0.0.1:8888 to use your application"
+  kubectl port-forward $POD_NAME 8888:{{ .Values.router.port }}
 {{- end }}


### PR DESCRIPTION
Change port forwarding commands to properly reflect intended use.
Problem: May not work if more than 1 router is created in kubectl cluster.