### PR TITLE
Values schema update

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,39 +187,39 @@ The following table lists the configurable parameters of the Druid Helm Chart an
 
 ### MiddleManager
 
-| Parameter                                                   | Description                                          | Default                     |
-| ----------------------------------------------------------- | ---------------------------------------------------- | --------------------------- |
-| `middleManager.enabled`                                     | enable middleManager                                 | `true`                      |
-| `middleManager.name`                                        | middleManager component name                         | `middleManager`             |
-| `middleManager.replicaCount`                                | middleManager node replicas (statefulset)            | `1`                         |
-| `middleManager.port`                                        | port of middleManager component                      | `8091`                      |
-| `middleManager.serviceType`                                 | service type for service                             | `ClusterIP`                 |
-| `middleManager.serviceAccount.create`                       | Create a service account for middleManager service   | `true`                      |
-| `middleManager.serviceAccount.name`                         | Service account name                                 | ``                          |
-| `middleManager.serviceAccount.annotations`                  | Annotations applied to created service account       | `{}`                        |
-| `middleManager.serviceAccount.labels`                       | Labels applied to created service account            | `{}`                        |
-| `middleManager.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account    | `true`                      |
-| `middleManager.resources`                                   | middleManager node resources requests & limits       | `{}`                        |
-| `middleManager.podAnnotations`                              | middleManager Deployment annotations                 | `{}`                        |
-| `middleManager.nodeSelector`                                | Node labels for middleManager pod assignment         | `{}`                        |
-| `middleManager.securityContext`                             | custom security context for middleManager containers | `{ fsGroup: 1000 }`         |
-| `middleManager.tolerations`                                 | middleManager tolerations                            | `[]`                        |
-| `middleManager.config`                                      | middleManager private config such as `JAVA_OPTS`     |                             |
-| `middleManager.persistence.enabled`                         | middleManager persistent enabled/disabled            | `true`                      |
-| `middleManager.persistence.size`                            | middleManager persistent volume size                 | `4Gi`                       |
-| `middleManager.persistence.storageClass`                    | middleManager persistent volume Class                | `nil`                       |
-| `middleManager.persistence.accessMode`                      | middleManager persistent Access Mode                 | `ReadWriteOnce`             |
-| `middleManager.antiAffinity`                                | middleManager anti-affinity policy                   | `soft`                      |
-| `middleManager.nodeAffinity`                                | middleManager node affinity policy                   | `{}`                        |
-| `middleManager.autoscaling.enabled`                         | enable horizontal pod autoscaling                    | `false`                     |
-| `middleManager.autoscaling.minReplicas`                     | middleManager autoscaling min replicas               | `2`                         |
-| `middleManager.autoscaling.maxReplicas`                     | middleManager autoscaling max replicas               | `5`                         |
-| `middleManager.autoscaling.metrics`                         | middleManager autoscaling metrics                    | `{}`                        |
-| `middleManager.ingress.enabled`                             | enable ingress                                       | `false`                     |
+| Parameter                                                   | Description                                          | Default                   |
+| ----------------------------------------------------------- | ---------------------------------------------------- |---------------------------|
+| `middleManager.enabled`                                     | enable middleManager                                 | `true`                    |
+| `middleManager.name`                                        | middleManager component name                         | `middleManager`           |
+| `middleManager.replicaCount`                                | middleManager node replicas (statefulset)            | `1`                       |
+| `middleManager.port`                                        | port of middleManager component                      | `8091`                    |
+| `middleManager.serviceType`                                 | service type for service                             | `ClusterIP`               |
+| `middleManager.serviceAccount.create`                       | Create a service account for middleManager service   | `true`                    |
+| `middleManager.serviceAccount.name`                         | Service account name                                 | ``                        |
+| `middleManager.serviceAccount.annotations`                  | Annotations applied to created service account       | `{}`                      |
+| `middleManager.serviceAccount.labels`                       | Labels applied to created service account            | `{}`                      |
+| `middleManager.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account    | `true`                    |
+| `middleManager.resources`                                   | middleManager node resources requests & limits       | `{}`                      |
+| `middleManager.podAnnotations`                              | middleManager Deployment annotations                 | `{}`                      |
+| `middleManager.nodeSelector`                                | Node labels for middleManager pod assignment         | `{}`                      |
+| `middleManager.securityContext`                             | custom security context for middleManager containers | `{ fsGroup: 1000 }`       |
+| `middleManager.tolerations`                                 | middleManager tolerations                            | `[]`                      |
+| `middleManager.config`                                      | middleManager private config such as `JAVA_OPTS`     |                           |
+| `middleManager.persistence.enabled`                         | middleManager persistent enabled/disabled            | `true`                    |
+| `middleManager.persistence.size`                            | middleManager persistent volume size                 | `4Gi`                     |
+| `middleManager.persistence.storageClass`                    | middleManager persistent volume Class                | `nil`                     |
+| `middleManager.persistence.accessMode`                      | middleManager persistent Access Mode                 | `ReadWriteOnce`           |
+| `middleManager.antiAffinity`                                | middleManager anti-affinity policy                   | `soft`                    |
+| `middleManager.nodeAffinity`                                | middleManager node affinity policy                   | `{}`                      |
+| `middleManager.autoscaling.enabled`                         | enable horizontal pod autoscaling                    | `false`                   |
+| `middleManager.autoscaling.minReplicas`                     | middleManager autoscaling min replicas               | `2`                       |
+| `middleManager.autoscaling.maxReplicas`                     | middleManager autoscaling max replicas               | `5`                       |
+| `middleManager.autoscaling.metrics`                         | middleManager autoscaling metrics                    | `[]`                      |
+| `middleManager.ingress.enabled`                             | enable ingress                                       | `false`                   |
 | `middleManager.ingress.hosts`                               | hosts for the middleManager api                      | `[ "chart-example.local" ]` |
-| `middleManager.ingress.path`                                | path of the middleManager api                        | `/`                         |
-| `middleManager.ingress.annotations`                         | annotations for the middleManager api ingress        | `{}`                        |
-| `middleManager.ingress.tls`                                 | TLS configuration for the ingress                    | `[]`                        |
+| `middleManager.ingress.path`                                | path of the middleManager api                        | `/`                       |
+| `middleManager.ingress.annotations`                         | annotations for the middleManager api ingress        | `{}`                      |
+| `middleManager.ingress.tls`                                 | TLS configuration for the ingress                    | `[]`                      |
 
 ### Historical
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -107,7 +107,10 @@
               "description": "Create a service account for router service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {
@@ -263,7 +266,10 @@
               "description": "Create a service account for broker service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {
@@ -429,7 +435,10 @@
               "description": "Create a service account for overlord service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {
@@ -590,7 +599,10 @@
               "description": "Create a service account for coordinator service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {
@@ -751,7 +763,10 @@
               "description": "Create a service account for middleManager service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {
@@ -975,7 +990,10 @@
               "description": "Create a service account for historical service"
             },
             "name": {
-              "type": "string",
+              "anyOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
               "description": "Service account name"
             },
             "annotations": {

--- a/values.schema.json
+++ b/values.schema.json
@@ -895,7 +895,35 @@
               "description": "middleManager autoscaling max replicas"
             },
             "metrics": {
-              "type": "object",
+              "type": "array",
+              "default": [],
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "resource": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "averageUtilization": {
+                            "type": "integer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               "description": "middleManager autoscaling metrics"
             }
           }


### PR DESCRIPTION
- Fix values.schema.json failing linting check with `helm lint .`
- Update documentation on case where middleManager.autoscaling.metrics is defined as object instead of array.