### PR TITLE
Update outdated API version

### DIFF
--- a/charts/druid/templates/middleManager/hpa.yaml
+++ b/charts/druid/templates/middleManager/hpa.yaml
@@ -18,7 +18,7 @@
 */}}
 
 {{- if .Values.middleManager.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "druid.middleManager.fullname" . }}

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -367,7 +367,7 @@ middleManager:
     druid_indexer_fork_property_druid_processing_buffer_sizeBytes: '25000000'
 
   autoscaling:
-    enabled: false
+    enabled: true
     minReplicas: 2
     maxReplicas: 5
     metrics:


### PR DESCRIPTION
Fixes #98 

Updates outdated apiVersion `autoscaling/v2beta2` to `autoscaling/v2`.