### PR TITLE
Support 33.0.0

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -15,8 +15,8 @@
 
 apiVersion: v2
 name: druid
-version: 31.0.5
-appVersion: 31.0.0
+version: 33.0.0-rc2
+appVersion: 33.0.0
 description: Apache Druid is a high performance real-time analytics database.
 keywords:
   - bigdata

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -28,7 +28,7 @@
 $ helm repo add druid-helm https://asdf2014.github.io/druid-helm/
 
 # Install chart
-$ helm install my-druid druid-helm/druid --version 31.0.5
+$ helm install my-druid druid-helm/druid --version 33.0.0
 ```
 
 
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the Druid Helm Chart an
 | Parameter                  | Description                                          | Default        |
 | -------------------------- | ---------------------------------------------------- | -------------- |
 | `image.repository`         | container image name                                 | `apache/druid` |
-| `image.tag`                | container image tag                                  | `31.0.0`       |
+| `image.tag`                | container image tag                                  | `33.0.0`       |
 | `image.pullPolicy`         | container pull policy                                | `IfNotPresent` |
 | `image.pullSecrets`        | image pull secrets for private repository            | `[]`           |
 | `configMap.enabled`        | enable druid configuration as configmap              | `true`         |

--- a/charts/druid/values.schema.json
+++ b/charts/druid/values.schema.json
@@ -13,7 +13,7 @@
         },
         "tag": {
           "type": "string",
-          "default": "30.0.1",
+          "default": "33.0.0",
           "description": "container image tag"
         },
         "pullPolicy": {

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -35,6 +35,7 @@ configVars:
   ## DRUID env vars. ref: https://github.com/apache/druid/blob/master/distribution/docker/druid.sh#L29
   # DRUID_LOG_LEVEL: "warn"
   # DRUID_LOG4J: <?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
+  DRUID_SET_HOST_IP: "1"
   DRUID_USE_CONTAINER_IP: "true"
 
   ## Druid Common Configurations. ref: https://druid.apache.org/docs/latest/configuration/index.html#common-configurations

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -17,7 +17,7 @@
 
 image:
   repository: apache/druid
-  tag: 30.0.1
+  tag: 33.0.0-rc2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
* update chart to use 33.0.0
* fixed that it was still using `30.0.1` under the hood for even versions after that
* added `DRUID_SET_HOST_IP=1` to retain ip based behaviour