### PR TITLE
fix(chore): Fix ingress configuration by updating `Ingress` `apiVersion`

### DIFF
--- a/charts/druid/templates/broker/ingress.yaml
+++ b/charts/druid/templates/broker/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.broker.ingress.enabled -}}
 {{- $fullName := include "druid.broker.fullname" . -}}
 {{- $ingressPath := .Values.broker.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/templates/broker/ingress.yaml
+++ b/charts/druid/templates/broker/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.broker.ingress.ingressClassName }}
 {{- if .Values.broker.ingress.tls }}
   tls:
   {{- range .Values.broker.ingress.tls }}

--- a/charts/druid/templates/coordinator/ingress.yaml
+++ b/charts/druid/templates/coordinator/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.coordinator.ingress.ingressClassName }}
 {{- if .Values.coordinator.ingress.tls }}
   tls:
   {{- range .Values.coordinator.ingress.tls }}

--- a/charts/druid/templates/coordinator/ingress.yaml
+++ b/charts/druid/templates/coordinator/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.coordinator.ingress.enabled -}}
 {{- $fullName := include "druid.coordinator.fullname" . -}}
 {{- $ingressPath := .Values.coordinator.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/templates/historical/ingress.yaml
+++ b/charts/druid/templates/historical/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.historical.ingress.ingressClassName }}
 {{- if .Values.historical.ingress.tls }}
   tls:
   {{- range .Values.historical.ingress.tls }}

--- a/charts/druid/templates/historical/ingress.yaml
+++ b/charts/druid/templates/historical/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.historical.ingress.enabled -}}
 {{- $fullName := include "druid.historical.fullname" . -}}
 {{- $ingressPath := .Values.historical.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/templates/middleManager/ingress.yaml
+++ b/charts/druid/templates/middleManager/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.middleManager.ingress.enabled -}}
 {{- $fullName := include "druid.middleManager.fullname" . -}}
 {{- $ingressPath := .Values.middleManager.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/templates/middleManager/ingress.yaml
+++ b/charts/druid/templates/middleManager/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.middleManager.ingress.ingressClassName }}
 {{- if .Values.middleManager.ingress.tls }}
   tls:
   {{- range .Values.middleManager.ingress.tls }}

--- a/charts/druid/templates/overlord/ingress.yaml
+++ b/charts/druid/templates/overlord/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.overlord.ingress.enabled -}}
 {{- $fullName := include "druid.overlord.fullname" . -}}
 {{- $ingressPath := .Values.overlord.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/templates/overlord/ingress.yaml
+++ b/charts/druid/templates/overlord/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.overlord.ingress.ingressClassName }}
 {{- if .Values.overlord.ingress.tls }}
   tls:
   {{- range .Values.overlord.ingress.tls }}

--- a/charts/druid/templates/router/ingress.yaml
+++ b/charts/druid/templates/router/ingress.yaml
@@ -36,6 +36,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.router.ingress.ingressClassName }}
 {{- if .Values.router.ingress.tls }}
   tls:
   {{- range .Values.router.ingress.tls }}

--- a/charts/druid/templates/router/ingress.yaml
+++ b/charts/druid/templates/router/ingress.yaml
@@ -20,7 +20,8 @@
 {{- if .Values.router.ingress.enabled -}}
 {{- $fullName := include "druid.router.fullname" . -}}
 {{- $ingressPath := .Values.router.ingress.path -}}
-apiVersion: extensions/v1beta1
+{{- $ingressPathType := .Values.broker.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -51,8 +52,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType}}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -77,8 +77,8 @@ broker:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:
@@ -133,8 +133,8 @@ coordinator:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:
@@ -186,8 +186,8 @@ overlord:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:
@@ -241,8 +241,8 @@ historical:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:
@@ -391,8 +391,8 @@ middleManager:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:
@@ -467,8 +467,8 @@ router:
   ingress:
     enabled: false
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    ingressClassName: ""
     path: /
     pathType: Prefix
     hosts:

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -80,6 +80,7 @@ broker:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []
@@ -135,6 +136,7 @@ coordinator:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []
@@ -187,6 +189,7 @@ overlord:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []
@@ -241,6 +244,7 @@ historical:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []
@@ -390,6 +394,7 @@ middleManager:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []
@@ -465,6 +470,7 @@ router:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     path: /
+    pathType: Prefix
     hosts:
       - chart-example.local
     tls: []


### PR DESCRIPTION
This updates the `Ingress` `apiVersion` from `extensions/v1beta1` to `networking.k8s.io/v1`. This was tested using the `ingress` and `ingress-dns` plugins available in `minikube`; see below for steps to reproduce. 

---

1. Start a `minikube` cluster:
```shell
minikube start
```

2. Follow the `ingress` and `ingress-dns` add-on guide for `minikube`; see [here](https://minikube.sigs.k8s.io/docs/handbook/addons/ingress-dns/#Linux). 

3. Create `values.yaml` containing the below:
```
router:
  ingress:
    enabled: true
    annotations:
      kubernetes.io/tls-acme: "true"
    ingressClassName: nginx
    hosts:
      - druid.test
    tls:
      - secretName: druid-router-tls
        hosts:
          - druid.test
```

4. Install Druid chart
```shell
helm install druid charts/druid --values values.yaml
```

5. Visit Druid front-end using browser at: [https://druid.test](https://druid.test).