### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1835,7 +1835,7 @@ entries:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r19
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: postgres-exporter
           image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r17
         - name: postgresql
@@ -1877,7 +1877,7 @@ entries:
       category: Infrastructure
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r27
+          image: docker.io/soldevelo/os-shell:12-debian-12-r3
         - name: zookeeper
           image: docker.io/bitnami/zookeeper:3.9.2-debian-12-r11
       licenses: Apache-2.0


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/os-shell:12-debian-12-r19` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r27` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)