### PR TITLE
Upgrade Apache Druid to 37.0.0

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -15,8 +15,8 @@
 
 apiVersion: v2
 name: druid
-version: 31.0.5
-appVersion: 31.0.0
+version: 37.0.0
+appVersion: 37.0.0
 description: Apache Druid is a high performance real-time analytics database.
 keywords:
   - bigdata

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -28,7 +28,7 @@
 $ helm repo add druid-helm https://asdf2014.github.io/druid-helm/
 
 # Install chart
-$ helm install my-druid druid-helm/druid --version 31.0.5
+$ helm install my-druid druid-helm/druid --version 37.0.0
 ```
 
 
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the Druid Helm Chart an
 | Parameter                  | Description                                          | Default        |
 | -------------------------- | ---------------------------------------------------- | -------------- |
 | `image.repository`         | container image name                                 | `apache/druid` |
-| `image.tag`                | container image tag                                  | `31.0.0`       |
+| `image.tag`                | container image tag                                  | `37.0.0`       |
 | `image.pullPolicy`         | container pull policy                                | `IfNotPresent` |
 | `image.pullSecrets`        | image pull secrets for private repository            | `[]`           |
 | `configMap.enabled`        | enable druid configuration as configmap              | `true`         |

--- a/charts/druid/values.schema.json
+++ b/charts/druid/values.schema.json
@@ -13,7 +13,7 @@
         },
         "tag": {
           "type": "string",
-          "default": "30.0.1",
+          "default": "37.0.0",
           "description": "container image tag"
         },
         "pullPolicy": {

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -17,7 +17,7 @@
 
 image:
   repository: apache/druid
-  tag: 30.0.1
+  tag: 37.0.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -35,7 +35,11 @@ configVars:
   ## DRUID env vars. ref: https://github.com/apache/druid/blob/master/distribution/docker/druid.sh#L29
   # DRUID_LOG_LEVEL: "warn"
   # DRUID_LOG4J: <?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
-  DRUID_USE_CONTAINER_IP: "true"
+  # Since Druid 33.0.0 the Docker entrypoint no longer sets druid.host to the container IP
+  # when running inside Kubernetes (apache/druid#17697). Most processes in this chart run as
+  # Deployments, whose pod hostnames are not resolvable in cluster DNS, so keep the previous
+  # IP-based announcement behaviour.
+  DRUID_SET_HOST_IP: "1"
 
   ## Druid Common Configurations. ref: https://druid.apache.org/docs/latest/configuration/index.html#common-configurations
   druid_extensions_loadList: '["druid-histogram", "druid-datasketches", "druid-lookups-cached-global", "postgresql-metadata-storage"]'


### PR DESCRIPTION
## What

- Bump chart `version` / `appVersion` and default `image.tag` to **37.0.0** (latest stable), aligning `Chart.yaml`, `values.yaml`, `values.schema.json` and `README.md`, which had drifted apart (chart 31.0.5 claimed appVersion 31.0.0 but actually deployed image `30.0.1` by default). Fixes #106.
- Add `DRUID_SET_HOST_IP: "1"` to `configVars`: since Druid 33.0.0 the Docker entrypoint defaults to canonical hostnames instead of the container IP when it detects Kubernetes (apache/druid#17697). This chart's processes mostly run as Deployments, whose pod hostnames are not resolvable in cluster DNS, so the previous IP-based announcement must be kept explicitly. Credit to @kgyrtkirk for catching this in #102 — this PR supersedes it.
- Remove `DRUID_USE_CONTAINER_IP`, a leftover the entrypoint no longer reads (checked `druid.sh` for 30.0.1 through 37.0.0).

## Upgrade-notes review (31 → 37)

Checked the [official upgrade notes](https://druid.apache.org/docs/latest/release-info/upgrade-notes/) for chart-level impact: the Docker host/IP change above is the only one affecting this chart. The default extension list (`druid-histogram`, `druid-datasketches`, `druid-lookups-cached-global`, `postgresql-metadata-storage`) survives unchanged; the image ships JDK 17 (Java 11 support removal is moot); removed features (Hadoop ingestion, legacy parsers) are not used by chart defaults.