### PR TITLE
Add missing RBAC permissions to coordinator role

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: druid
-version: 37.0.0
+version: 37.0.1
 appVersion: 37.0.0
 description: Apache Druid is a high performance real-time analytics database.
 keywords:

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -28,7 +28,7 @@
 $ helm repo add druid-helm https://asdf2014.github.io/druid-helm/
 
 # Install chart
-$ helm install my-druid druid-helm/druid --version 37.0.0
+$ helm install my-druid druid-helm/druid --version 37.0.1
 ```
 
 

--- a/charts/druid/templates/coordinator/role.yaml
+++ b/charts/druid/templates/coordinator/role.yaml
@@ -34,6 +34,17 @@ rules:
     resources:
       - pods
       - configmaps
+      - pods/log
+    verbs:
+      - '*'
+  # Needed when the coordinator acts as overlord (druid.coordinator.asOverlord.enabled)
+  # with the druid-kubernetes-overlord-extensions task runner, which manages peon Jobs
+  # through the Kubernetes API. Mirrors the dedicated overlord role; see
+  # https://druid.apache.org/docs/latest/development/extensions-contrib/k8s-jobs/#gotchas
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
     verbs:
       - '*'
 {{- end }}


### PR DESCRIPTION
## What

Align the coordinator Role with the overlord Role: add `pods/log` and `batch`/`jobs` rules. Bump chart version to 37.0.1 (chart-releaser skips already-published versions, so a template-only change would never ship).

## Why

When Druid runs the coordinator as overlord (`druid.coordinator.asOverlord.enabled=true`, a common resource-saving setup) together with the `druid-kubernetes-overlord-extensions` K8s task runner, the runner executes inside the coordinator process and calls the Kubernetes API with the coordinator's ServiceAccount — e.g. `GET /apis/batch/v1/.../jobs?labelSelector=druid.k8s.peons`. The coordinator Role only granted `pods` + `configmaps`, so these calls fail with `Forbidden`, exactly as reported in #103.

The dedicated overlord Role already carries `batch/jobs` and `pods/log` (the latter added in #105), and the [official k8s-jobs gotchas](https://druid.apache.org/docs/latest/development/extensions-contrib/k8s-jobs/#gotchas) document both. This is a namespaced Role rendered only when `rbac.create=true`; default installs are unaffected.

Fixes #103. Thanks @alzelk for the precise report and the proposed rule.