### PR TITLE
Clean up dead ZooKeeper subchart values

### DIFF
--- a/charts/druid/Chart.yaml
+++ b/charts/druid/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: druid
-version: 37.0.1
+version: 37.0.2
 appVersion: 37.0.0
 description: Apache Druid is a high performance real-time analytics database.
 keywords:

--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -28,7 +28,7 @@
 $ helm repo add druid-helm https://asdf2014.github.io/druid-helm/
 
 # Install chart
-$ helm install my-druid druid-helm/druid --version 37.0.1
+$ helm install my-druid druid-helm/druid --version 37.0.2
 ```
 
 
@@ -264,7 +264,7 @@ The following table lists the configurable parameters of the Druid Helm Chart an
 | `postgresql.auth.username` | PostgreSQL username     | `druid` |
 | `postgresql.auth.password` | PostgreSQL password     | `druid` |
 | `postgresql.auth.database` | PostgreSQL database     | `druid` |
-| `postgresql.service.port`  | PostgreSQL service port | `5432`  |
+| `postgresql.service.port`  | PostgreSQL port used in the metadata connectURI (the subchart's actual port lives at `postgresql.primary.service.ports.postgresql`) | `5432`  |
 
 ### Prometheus
 

--- a/charts/druid/values.yaml
+++ b/charts/druid/values.yaml
@@ -32,7 +32,7 @@ rbac:
 
 ## Define the key value pairs in the configmap
 configVars:
-  ## DRUID env vars. ref: https://github.com/apache/druid/blob/master/distribution/docker/druid.sh#L29
+  ## DRUID env vars. ref: https://github.com/apache/druid/blob/master/distribution/docker/druid.sh
   # DRUID_LOG_LEVEL: "warn"
   # DRUID_LOG4J: <?xml version="1.0" encoding="UTF-8" ?><Configuration status="WARN"><Appenders><Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="%d{ISO8601} %p [%t] %c - %m%n"/></Console></Appenders><Loggers><Root level="info"><AppenderRef ref="Console"/></Root><Logger name="org.apache.druid.jetty.RequestLog" additivity="false" level="DEBUG"><AppenderRef ref="Console"/></Logger></Loggers></Configuration>
   # Since Druid 33.0.0 the Docker entrypoint no longer sets druid.host to the container IP
@@ -519,14 +519,14 @@ router:
 
 zookeeper:
   enabled: true
-  ## Environmental variables to set in ZooKeeper
-  ##
-  env:
-    ## The JVM heap size to allocate to ZooKeeper
-    ZK_HEAP_SIZE: "512M"
-  ## Configure ZooKeeper headless
-  headless:
-    publishNotReadyAddresses: true
+  ## ZooKeeper JVM heap size in MB, consumed by the Bitnami subchart. 1024 is the subchart
+  ## default and the value that has always been in effect here: the former
+  ## `env.ZK_HEAP_SIZE: 512M` stanza was a leftover from the old helm/stable ZooKeeper chart
+  ## and was silently ignored by the Bitnami one, so it is made explicit at 1024 rather than
+  ## "restored" to 512 to avoid changing the memory footprint of existing installs.
+  ## (Likewise, the Bitnami subchart publishes not-ready headless addresses by default, so
+  ## the former `headless.publishNotReadyAddresses: true` block was a no-op and is gone.)
+  heapSize: 1024
 
 # ------------------------------------------------------------------------------
 # MySQL:
@@ -553,6 +553,9 @@ postgresql:
     password: druid
     database: druid
   service:
+    # Only used by this chart to build the metadata-storage connectURI. Changing it does NOT
+    # move the Bitnami subchart's actual listening port (that lives at
+    # postgresql.primary.service.ports.postgresql); keep the two in sync if you change either.
     port: 5432
 
 # Secrets


### PR DESCRIPTION
## What

- Remove two no-op values inherited from the old helm/stable ZooKeeper chart and make the effective heap explicit:
  - `zookeeper.env.ZK_HEAP_SIZE: "512M"` — the Bitnami subchart never reads `env`; its heap comes from `heapSize` (default 1024 MB). Replaced with an explicit `zookeeper.heapSize: 1024`, matching what has actually been running, rather than "restoring" 512M and silently halving ZooKeeper memory on existing installs.
  - `zookeeper.headless.publishNotReadyAddresses: true` — the Bitnami path is `service.headless.publishNotReadyAddresses` and it already defaults to `true`, so this block had no effect.
- Document that `postgresql.service.port` only feeds the metadata `connectURI` built by this chart; the Bitnami subchart's actual listening port lives at `postgresql.primary.service.ports.postgresql`.
- Drop the drifted `#L29` anchor from the `druid.sh` reference comment.
- Bump chart version to 37.0.2 (chart-releaser skips published versions).

## Verification

Confirmed against the packaged Bitnami ZooKeeper 13.4.15: its statefulset reads `.Values.heapSize` (and nothing reads `.Values.env`), and `service.headless.publishNotReadyAddresses` defaults to `true`. Also audited every `druid_*`/`DRUID_*` key in `values.yaml` against apache/druid master (`distribution/docker/druid.sh` is unchanged since 37.0.0, and none of the chart's runtime properties appear in the 31→37 removed-configs lists) — no other stale settings found.

No behavior change for existing installs.