### PR TITLE
Replace broken OpenCollective contributors badge with contrib.rocks

### DIFF
--- a/charts/druid/README.md
+++ b/charts/druid/README.md
@@ -300,4 +300,4 @@ MiddleManagers and Historicals use StatefulSet. Persistence has been enabled by 
 
 # Thanks
 
-[![](https://opencollective.com/druid-helm/contributors.svg?width=666)](https://github.com/asdf2014/druid-helm/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=asdf2014/druid-helm)](https://github.com/asdf2014/druid-helm/graphs/contributors)


### PR DESCRIPTION
## What

The `opencollective.com/druid-helm/contributors.svg` widget in the Thanks section now returns HTTP 500 (verified), so the README shows a broken image. Replace it with [contrib.rocks](https://contrib.rocks), which renders the same avatar wall for GitHub contributors, refreshes daily, and inlines avatars as base64 into a single SVG — verified working for this repo: https://contrib.rocks/image?repo=asdf2014/druid-helm

No chart content changes, so no version bump: chart-releaser skips the existing 37.0.2 on merge, and the GitHub-facing README updates immediately (the packaged copy catches up with the next release).